### PR TITLE
Notify New Relic only if app ID and key are set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 ## master
 [6.1.0...master](https://github.com/deployphp/recipes/compare/6.1.0...master)
 
+### Fixed
+- Fixed malformed New Relic deployment payload when ID/key falsy (#193)
 
 ## 6.1.0
 [6.0.2...6.1.0](https://github.com/deployphp/recipes/compare/6.0.2...6.1.0)

--- a/recipe/newrelic.php
+++ b/recipe/newrelic.php
@@ -23,19 +23,18 @@ set('newrelic_revision', function() {
 
 desc('Notifying New Relic of deployment');
 task('newrelic:notify', function () {
-    $appId = get('newrelic_app_id');
-    $apiKey = get('newrelic_api_key');
+    if (($appId = get('newrelic_app_id')) && ($apiKey = get('newrelic_api_key'))) {
+        $data = [
+            'user' => get('user'),
+            'revision' => get('newrelic_revision'),
+            'description' => get('newrelic_description'),
+        ];
 
-    $data = [
-        'user' => get('user'),
-        'revision' => get('newrelic_revision'),
-        'description' => get('newrelic_description'),
-    ];
-
-    Httpie::post("https://api.newrelic.com/v2/applications/$appId/deployments.json")
-        ->header("X-Api-Key: $apiKey")
-        ->query(['deployment' => $data])
-        ->send();
+        Httpie::post("https://api.newrelic.com/v2/applications/$appId/deployments.json")
+            ->header("X-Api-Key: $apiKey")
+            ->query(['deployment' => $data])
+            ->send();
+    }
 })
     ->once()
     ->shallow()


### PR DESCRIPTION
This allows setting the app ID to false when deploying to environments not monitored by New Relic. You'll still receive an error message if you don't manually override `newrelic_app_id`.

| Q             | A
| ------------- | ---
| Bug fix?      | No
| New feature?  | Yes
| BC breaks?    | No
| Deprecations? | No
| Fixed tickets | #193
